### PR TITLE
Fix Dependabot alert: bump markdown-it to 14.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2913,9 +2913,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",


### PR DESCRIPTION
Dependabot reported a moderate ReDoS vulnerability in markdown-it (GHSA-38c4-r59v-3vqw).

This PR updates the lockfile to markdown-it 14.1.1 via npm audit fix and verifies the site still builds (astro build).