### PR TITLE
chore(deps): bump devalue to 5.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.10",
         "astro": "^5.16.6",
+        "devalue": "5.6.3",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.1",
         "markdown-it": "^14.1.0",
@@ -2158,9 +2159,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
+      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "license": "MIT"
     },
     "node_modules/devlop": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@astrojs/markdown-remark": "^6.3.10",
     "astro": "^5.16.6",
+    "devalue": "5.6.3",
     "gray-matter": "^4.0.3",
     "js-yaml": "^4.1.1",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
Bumps devalue from 5.6.2 to 5.6.3 to address Dependabot alerts.